### PR TITLE
ドラッグ&ドロップ後DB保存

### DIFF
--- a/app/controllers/api/fruits_controller.rb
+++ b/app/controllers/api/fruits_controller.rb
@@ -22,6 +22,13 @@ class Api::FruitsController < ApplicationController
     end
   end
 
+  def destroy
+    @fruit = Fruit.find(params[:id])
+    if @fruit.destroy
+      head :no_content
+    end
+  end
+
   private
     def fruit_params
       params.require(:fruit).permit(:name, :description, :position)

--- a/app/controllers/api/fruits_controller.rb
+++ b/app/controllers/api/fruits_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Api::FruitsController < ApplicationController
+
+  def create
+    def create
+      @fruit = Fruit.new(fruit_params)
+      if @fruit.save
+        render :show, status: :created, location: @fruit
+      else
+        render json: @fruit.errors, status: :unprocessable_entity
+      end
+    end
+  end
+
+  def update
+    @fruit = Fruit.find(params[:id])
+    if @fruit.update(fruit_params)
+      render :show, status: :ok, location: @fruit
+    else
+      render json: @fruit.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def fruit_params
+      params.require(:fruit).permit(:name, :description, :position)
+    end
+end

--- a/app/controllers/fruits_controller.rb
+++ b/app/controllers/fruits_controller.rb
@@ -71,6 +71,6 @@ class FruitsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def fruit_params
-      params.require(:fruit).permit(:name, :description)
+      params.require(:fruit).permit(:name, :description, :position)
     end
 end

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -4,8 +4,12 @@ import App from './app.vue'
 document.addEventListener('DOMContentLoaded', () => {
   const app = document.getElementById('js-index')
   if (app) {
+    const fruitsData = app.getAttribute('data-fruits')
     new Vue({
-      render: h => h(App)
+      render: h => h(App, { props: {
+        fruitsData: fruitsData
+        }
+      })
     }).$mount('#js-index')
   }
 })

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -7,7 +7,7 @@
         <tr>
           <th>Name</th>
           <th>Description</th>
-          <th></th>
+          <th>Position</th>
           <th></th>
           <th></th>
         </tr>
@@ -16,6 +16,9 @@
         <tr v-for="fruit in fruits">
           <td>{{ fruit.name }}</td>
           <td>{{ fruit.description }}</td>
+          <td>{{ fruit.position }}</td>
+          <td><a :href="`/fruits/${fruit.id}/edit`">Edit</a></td>
+          <td><a>Destroy</a></td>
         </tr>
       </draggable>
     </table>
@@ -29,9 +32,8 @@ import draggable from "vuedraggable"
 export default {
   data() {
     return {
-      message: "Hello Vue!",
       fruits: [],
-      dragging: false
+      dragging: false,
     }
   },
   components: {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -18,7 +18,7 @@
           <td>{{ fruit.description }}</td>
           <td>{{ fruit.position }}</td>
           <td><a :href="`/fruits/${fruit.id}/edit`">Edit</a></td>
-          <td><a>Destroy</a></td>
+          <td><a @click="destroyFruit(fruit.id)">Destroy</a></td>
         </tr>
       </draggable>
     </table>
@@ -33,11 +33,42 @@ export default {
   data() {
     return {
       fruits: [],
-      dragging: false,
+      dragging: false
     }
   },
   components: {
     draggable
+  },
+  methods: {
+    token () {
+      const meta = document.querySelector('meta[name="csrf-token"]')
+      return meta ? meta.getAttribute('content') : ''
+    },
+    destroyFruit(id) {
+      let params = {
+        id: this.id
+      }
+      fetch(`/fruits/${id}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': this.token()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual',
+        body: JSON.stringify(params)
+      })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.blob();
+      })
+      .catch(error => {
+        console.error('There has been a problem with your fetch operation:', error)
+      })
+    }
   },
   created() {
     fetch('/fruits.json', {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -90,29 +90,31 @@ export default {
       })
     },
     destroyFruit(id) {
-      let params = {
-        id: this.id
-      }
-      fetch(`/fruits/${id}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRF-Token': this.token()
-        },
-        credentials: 'same-origin',
-        redirect: 'manual',
-        body: JSON.stringify(params)
-      })
-      .then(response => {
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
+      if (window.confirm('削除してよろしいですか？')) {
+        let params = {
+          id: this.id
         }
-        return response.blob();
-      })
-      .catch(error => {
-        console.error('There has been a problem with your fetch operation:', error)
-      })
+        fetch(`/fruits/${id}`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-Token': this.token()
+          },
+          credentials: 'same-origin',
+          redirect: 'manual',
+          body: JSON.stringify(params)
+        })
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.blob();
+        })
+        .catch(error => {
+          console.error('There has been a problem with your fetch operation:', error)
+        })
+      }
     },
     dropped() {
       this.fruits.forEach((fruit, index) => {

--- a/app/views/api/fruits/_fruit.json.jbuilder
+++ b/app/views/api/fruits/_fruit.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.extract! fruit, :id, :name, :description, :created_at, :updated_at, :position

--- a/app/views/api/fruits/show.json.jbuilder
+++ b/app/views/api/fruits/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "fruits/fruit", fruit: @fruit

--- a/app/views/fruits/index.html.slim
+++ b/app/views/fruits/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing fruits
-#js-index
+#js-index(data-fruits="#{@fruits.to_json}")
 table
   thead
     tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   resources :books
   resources :fruits
   namespace :api do
-    resources :fruits, only: %i(create update)
+    resources :fruits, only: %i(create update destroy)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,7 @@ Rails.application.routes.draw do
   root "home#index"
   resources :books
   resources :fruits
+  namespace :api do
+    resources :fruits, only: %i(create update)
+  end
 end


### PR DESCRIPTION
やりたいこと

- [x] 項目をドラッグ&ドロップできるようにする
- [x] ドラッグ&ドロップ後のpositionをDB保存する
- [x] Edit、Destroyリンクを作成し、scaffoldしたときと同じ動作にする

<details><summary>修正済み</summary>

現状
- Edit（リンクのみ）
    - 多分問題なし
- create/destroy
    - create/destroyできるが再描画されない
    - ~~Destroyをクリック後アラートが出ない~~
- update
    - 全部のpositionをupdateしようとしていてエラーになる
    - DBがロックされている?
- Turbolinksは無効化している

仮説
- ドラッグ&ドロップした項目だけupdateすればよさそう
- rails console で1つのfruitだけpositionを変更すると他は自動で更新される（acts_as_list側でやってくれる）
    - https://github.com/brendon/acts_as_list/blob/master/lib/acts_as_list/active_record/acts/callback_definer.rb
    - https://github.com/brendon/acts_as_list/blob/49427dc876408668b7aa7b8ff21273250087348b/lib/acts_as_list/active_record/acts/list.rb#L411

</details>