### PR TITLE
ドラッグ&ドロップ用のハンドルを設定

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -114,4 +114,7 @@ export default {
 p, .center {
   text-align: center;
 }
+.handle {
+  cursor: grab;
+}
 </style>

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -7,14 +7,16 @@
           <th>Description</th>
           <th></th>
           <th></th>
+          <th>並び替え</th>
         </tr>
       </thead>
-      <draggable v-model="fruits" tag="tbody" @start="start" @end="dropped">
+      <draggable v-model="fruits" handle=".handle" tag="tbody" @start="start" @end="dropped">
         <tr v-for="fruit in fruits" :key="fruit.id" @dragstart="dragstart(fruit)">
           <td>{{ fruit.name }}</td>
           <td>{{ fruit.description }}</td>
           <td><a :href="`/fruits/${fruit.id}/edit`">Edit</a></td>
           <td><a @click="destroyFruit(fruit)">Destroy</a></td>
+          <td class="center"><span class="handle">::</span></td>
         </tr>
       </draggable>
     </table>
@@ -109,7 +111,7 @@ export default {
 </script>
 
 <style scoped>
-p {
+p, .center {
   text-align: center;
 }
 </style>


### PR DESCRIPTION
## やったこと

- ハンドルを作り、ハンドル以外の場所ではドラッグ&ドロップできないようにした

![handle2](https://user-images.githubusercontent.com/58389623/102758738-863a2b00-43b6-11eb-896c-b0634cf37b20.gif)

## 変更前

- テーブル上のどこでもドラッグ&ドロップが可能だった

![draggable](https://user-images.githubusercontent.com/58389623/102694419-482cf200-4264-11eb-844d-178037758154.gif)