### PR TITLE
wrap_parametersを使用するようにした

### DIFF
--- a/app/controllers/api/fruits/position_controller.rb
+++ b/app/controllers/api/fruits/position_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::Fruits::PositionController < ApplicationController
+  wrap_parameters :category
+
   def update
     @fruit = Fruit.find(params[:fruit_id])
     if @fruit.update(fruit_params)
@@ -12,6 +14,6 @@ class Api::Fruits::PositionController < ApplicationController
 
   private
     def fruit_params
-      params.permit(:position)
+      params.require(:category).permit(:position)
     end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -58,7 +58,7 @@ export default {
       const newPosition = this.fruits.findIndex((v) => v.id === targetId) + 1
       if (this.oldPosition !== newPosition) {
         const params = {
-          'position': newPosition
+          position: newPosition
         }
         fetch(`/api/fruits/${targetId}/position.json`, {
           method: 'PATCH',


### PR DESCRIPTION
`Unpermitted parameters: :fruit_id, :format`警告への対応。